### PR TITLE
el capitan dylib fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ make
 cp *.jar ../..
 cp *.dylib ../.. || cp *.so ../..
 cd ../..
+otool -L libz3java.dylib #this should show "libz3.dylib" with some version info behind it
+install_name_tool -change libz3.dylib `pwd`/libz3.dylib libz3java.dylib
 ```
 
 (3) In order to use the Android clients or compile/run the tests, you'll need a Droidel-processed Android framework JAR in lib/: `cp ../droidel/stubs/out/droidel_android-4.4.2_r1.jar lib` (assuming `droidel` and `hopper` are sibling directories).

--- a/hopper.sh
+++ b/hopper.sh
@@ -11,4 +11,5 @@ LIB=$(pwd)/lib
 export LD_LIBRARY_PATH=$LIB:$LD_LIBRARY_PATH
 export DYLD_LIBRARY_PATH=$LIB:$DYLD_LIBRARY_PATH
 
-java -Xmx8g -jar $JAR $@
+echo $DYLD_LIBRARY_PATH
+java -Djava.library.path=$LIB -Xmx8g -jar $JAR $@


### PR DESCRIPTION
The environment variable DYLD_LIBRARY_PATH no longer has any effect on OSx El capitan.  This patch makes it work.  I suspect there is a better way to do this so suggestions are welcome.
